### PR TITLE
Set Result field on ResultException

### DIFF
--- a/cs-examples/unity-examples/Assets/Plugins/DiscordGameSDK/Core.cs
+++ b/cs-examples/unity-examples/Assets/Plugins/DiscordGameSDK/Core.cs
@@ -694,6 +694,7 @@ namespace Discord
 
         public ResultException(Result result) : base(result.ToString())
         {
+            Result = result;
         }
     }
 


### PR DESCRIPTION
Fixes being unable to check why the exception was thrown.